### PR TITLE
Fix issue with finding package.json outside of root

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ const { execSync } = require('child_process')
 
 // Change working directory if user defined PACKAGEJSON_DIR
 if (process.env.PACKAGEJSON_DIR) {
-  process.chdir(`${process.env.GITHUB_WORKSPACE}/${process.env.PACKAGEJSON_DIR}`)
+  process.env.GITHUB_WORKSPACE = `${process.env.GITHUB_WORKSPACE}/${process.env.PACKAGEJSON_DIR}`
+  process.chdir(process.env.GITHUB_WORKSPACE)
 }
 
 // Run your GitHub Action!


### PR DESCRIPTION
This update fixes an issue with finding the package.json file using the user-defined PACKAGEJSON_DIR (when package.json isn't in the root directory). The issue was that the actions-tookit's getPackageJSON() method only looks in the GITHUB_WORKSPACE directory, so since we weren't setting that, it was unable to find the file.