### PR TITLE
feat: Add support for  syntax for breaking change.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ Toolkit.run(async tools => {
   }
 
   let version = 'patch'
-  if (messages.map(message => message.includes('BREAKING CHANGE') || message.includes('major')).includes(true)) {
+  if (messages.map(message => message.match(/^([a-zA-Z]+)(\(.+\))?(\!)\:/) || message.includes('BREAKING CHANGE') || message.includes('major')).includes(true)) {
     version = 'major'
   } else if (messages.map(
     message => message.toLowerCase().startsWith('feat') || message.toLowerCase().includes('minor')).includes(true)) {


### PR DESCRIPTION
This PR adds support for the `!` syntax for marking a `BREAKING CHANGE`, as per the latest spec:

See points 1. and 13. from [the specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)