### PR TITLE
fix: `!` breaking change syntax regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ Toolkit.run(async tools => {
   }
 
   let version = 'patch'
-  if (messages.map(message => message.match(/^([a-zA-Z]+)(\(.+\))?(\!)\:/) || message.includes('BREAKING CHANGE') || message.includes('major')).includes(true)) {
+  if (messages.map(message => /^([a-zA-Z]+)(\(.+\))?(\!)\:/.test(message) || message.includes('BREAKING CHANGE') || message.includes('major')).includes(true)) {
     version = 'major'
   } else if (messages.map(
     message => message.toLowerCase().startsWith('feat') || message.toLowerCase().includes('minor')).includes(true)) {


### PR DESCRIPTION
This PR replaces `match` with `test`. `match` returns an array of the matched sections of a string, but `test` returns `true` or `false`, which is what the `includes` is checking against