### PR TITLE
Support for prerelease and --preId

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Make sure you use the `actions/checkout@v2` action!
     version will be incremented.
   * If a commit message begins with the string "feat" or includes "minor" then the minor version will be increased. This works
     for most common commit metadata for feature additions: `"feat: new API"` and `"feature: new API"`.
+  * If a commit message contains the word "prerelease" then the pre-release version will be increased (for example 1.6.0-alpha.1 -> 1.6.0-alpha.2)
   * All other changes will increment the patch version.
 * Push the bumped npm version in package.json back into the repo.
 * Push a tag for the new version back into the repo.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Make sure you use the `actions/checkout@v2` action!
     version will be incremented.
   * If a commit message begins with the string "feat" or includes "minor" then the minor version will be increased. This works
     for most common commit metadata for feature additions: `"feat: new API"` and `"feature: new API"`.
-  * If a commit message contains the word "prerelease" then the pre-release version will be increased (for example 1.6.0-alpha.1 -> 1.6.0-alpha.2)
+  * If a commit message contains the word "pre-alpha" or "pre-beta" or "pre-rc" then the pre-release version will be increased (for example specifying pre-alpha: 1.6.0-alpha.1 -> 1.6.0-alpha.2 or, specifying pre-beta: 1.6.0-alpha.1 -> 1.6.0-beta.0)
   * All other changes will increment the patch version.
 * Push the bumped npm version in package.json back into the repo.
 * Push a tag for the new version back into the repo.

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ Toolkit.run(async tools => {
   const event = tools.context.payload
 
   if (!event.commits) {
-    console.log('Couldn\'t find any commits in this event, incrementing patch/prerelease version...')
+    console.log('Couldn\'t find any commits in this event, incrementing patch version...')
   }
 
   const messages = event.commits ? event.commits.map(commit => commit.message + '\n' + commit.body) : []

--- a/index.js
+++ b/index.js
@@ -28,28 +28,27 @@ Toolkit.run(async tools => {
 
   const majorWords = process.env['INPUT_MAJOR-WORDING'].split(',')
   const minorWords = process.env['INPUT_MINOR-WORDING'].split(',')
-  const prereleaseWords = ['preprelease', 'alpha', 'beta', 'rc']
+  const preReleaseWords = ['pre-alpha', 'pre-beta', 'pre-rc']
 
   let version = 'patch'
-  let preid = null;
-  let foundWords = [];
-
+  let foundWord = null;
+  
   if (messages.some(
     message => /^([a-zA-Z]+)(\(.+\))?(\!)\:/.test(message) || majorWords.some(word => message.includes(word)))) {
     version = 'major'
   } else if (messages.some(message => minorWords.some(word => message.includes(word)))) {
     version = 'minor'
-  } else if (messages.some(message => prereleaseWords.some(word => {
+  } else if (messages.some(message => preReleaseWords.some(word => {
         if (message.includes(word)) {
-          foundWords.push(word);
+          foundWord = word;
           return true;
         } else {
           return false;
         }
       }
     ))) {
-    version = 'prerelease';
-    console.log(foundWords);
+      let preid = foundWord.split("-")[1];
+      version = `prerelease --preid=${preid}`;
   }
 
   try {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ Toolkit.run(async tools => {
   const event = tools.context.payload
 
   if (!event.commits) {
-    console.log('Couldn\'t find any commits in this event, incrementing patch version...')
+    console.log('Couldn\'t find any commits in this event, incrementing patch/prerelease version...')
   }
 
   const messages = event.commits ? event.commits.map(commit => commit.message + '\n' + commit.body) : []
@@ -34,6 +34,8 @@ Toolkit.run(async tools => {
     version = 'major'
   } else if (messages.some(message => minorWords.some(word => message.includes(word)))) {
     version = 'minor'
+  } else if (messages.some(message => message.includes('prerelease'))) {
+    version = 'prerelease'
   }
 
   try {

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ Toolkit.run(async tools => {
         }
       }
     ))) {
-      let preid = foundWord.split("-")[1];
+      const preid = foundWord.split("-")[1];
       version = `prerelease --preid=${preid}`;
   }
 

--- a/index.js
+++ b/index.js
@@ -28,14 +28,28 @@ Toolkit.run(async tools => {
 
   const majorWords = process.env['INPUT_MAJOR-WORDING'].split(',')
   const minorWords = process.env['INPUT_MINOR-WORDING'].split(',')
+  const prereleaseWords = ['preprelease', 'alpha', 'beta', 'rc']
+
   let version = 'patch'
+  let preid = null;
+  let foundWords = [];
+
   if (messages.some(
     message => /^([a-zA-Z]+)(\(.+\))?(\!)\:/.test(message) || majorWords.some(word => message.includes(word)))) {
     version = 'major'
   } else if (messages.some(message => minorWords.some(word => message.includes(word)))) {
     version = 'minor'
-  } else if (messages.some(message => message.includes('prerelease'))) {
-    version = 'prerelease'
+  } else if (messages.some(message => prereleaseWords.some(word => {
+        if (message.includes(word)) {
+          foundWords.push(word);
+          return true;
+        } else {
+          return false;
+        }
+      }
+    ))) {
+    version = 'prerelease';
+    console.log(foundWords);
   }
 
   try {


### PR DESCRIPTION
With this PR is possible to support the pre-release:

for example `1.6.0-alpha.1`

If a commit comment contains one of the words: `pre-alpha`. `pre-beta` or `pre-rc`, the action will increase the pre-release version.
This is a fallback of major and minor.

Examples:
- "This is a **pre-alpha** version" ---> transform a version `1.6.0` into `1.6.1-alpha.0`
- "This is a **pre-alpha** version" ---> transform a version `1.6.1-alpha.0` into `1.6.1-alpha.1`
- "This is a **pre-beta** version" ---> transform a version `1.6.1-alpha.1` into `1.6.1-beta.0`
- "This is a **pre-rc** version" ---> transform a version `1.6.1-beta.0` into `1.6.1-rc.0`
- "This is an empty comment" ---> transform a version `1.6.1-rc.0` into `1.6.2`

and so on.


