### PR TITLE
Support for changing the default version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Make sure you use the `actions/checkout@v2` action!
     skip-tag:  'true'
 ```
 
+**default:** Set a default version bump to use  (optional - defaults to patch). Example:
+```yaml
+- name:  'Automated Version Bump'
+  uses:  'phips28/gh-action-bump-version@master'
+  with:
+    default: prerelease
+```
+
 **wording:** Customize the messages that trigger the version bump. It must be a string, case sensitive, coma separated  (optional). Example:
 ```yaml
 - name:  'Automated Version Bump'

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ Toolkit.run(async tools => {
   const patchWords = process.env['INPUT_PATCH-WORDING'].split(',')
   const preReleaseWords = process.env['INPUT_RC-WORDING'].split(',')
 
-  let version = 'patch'
+  let version = process.env['DEFAULT'] || 'patch'
   let foundWord = null;
   
   if (messages.some(


### PR DESCRIPTION
Allows you to change the default version bump from `path` to whatever you'd like using the new `default` variable