### PR TITLE
Fix: Action was not default to patch anymore

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ Toolkit.run(async tools => {
   ))) {
     const preid = foundWord.split('-')[1]
     version = `prerelease --preid=${preid}`
-  } else if (patchWords && Array.isArray(patchWords)) {
+  } else if (patchWords && Array.isArray(patchWords) && patchWords.length) {
     if (!messages.some(message => patchWords.some(word => message.includes(word)))) {
       version = null
     }


### PR DESCRIPTION
Hi, I'm using the last version of this github action and it doesn't resolve to patch anymore, it says
```
Couldn't find any commits in this event, incrementing patch version...
messages: []
✔  success   No version keywords found, skipping bump.
```
I believe this is because patchWords is an empty array, which then makes it enter the condition line 54, and since it's written negatively version will be set to null.

I don't really understand why patchWords is an empty array, but I'm guessing `process.env['INPUT_PATCH-WORDING']` results in an empty string. (if that wasn't the case it would crash line 31 saying `cannot read property split of undefined`).