### PR TITLE
FIX: patch version bumps

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,10 @@ Toolkit.run(async tools => {
 
   const majorWords = process.env['INPUT_MAJOR-WORDING'].split(',')
   const minorWords = process.env['INPUT_MINOR-WORDING'].split(',')
-  const patchWords = process.env['INPUT_PATCH-WORDING'].split(',')
   const preReleaseWords = process.env['INPUT_RC-WORDING'].split(',')
+  
+  // if patch words aren't specified, any commit message qualifies as a patch
+  const patchWords = process.env['INPUT_PATCH-WORDING'] ? process.env['INPUT_PATCH-WORDING'].split(',') : null
 
   let version = process.env.INPUT_DEFAULT || 'patch'
   let foundWord = null
@@ -50,7 +52,7 @@ Toolkit.run(async tools => {
   ))) {
     const preid = foundWord.split('-')[1]
     version = `prerelease --preid=${preid}`
-  } else if (patchWords && Array.isArray(patchWords) && patchWords.length) {
+  } else if (Array.isArray(patchWords) && patchWords.length) {
     if (!messages.some(message => patchWords.some(word => message.includes(word)))) {
       version = null
     }


### PR DESCRIPTION
#64 identified the issue, but the problem persists. From what I can tell, the value of `process.env['INPUT_PATCH-WORDING']` is the empty string, which returns `['']` when `.split(',')` is called.

so then in the conditional, `patchWords === ['']`, which evaluates to true and causes the version to be nulled out.