### PR TITLE
Allow the version upgrade to be executed on a separate branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,13 @@ Make sure you use the `actions/checkout@v2` action!
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     PACKAGEJSON_DIR:  'frontend'
 ```
+
+**TARGET-BRANCH:** Set a custom target branch to use when bumping the version. Useful in cases such as updating the version on master after a tag has been set (optional). Example:
+```yaml
+- name:  'Automated Version Bump'
+  uses:  'phips28/gh-action-bump-version@master'
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    target-branch: 'master'
+```

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
     description: 'Custom dir to the package'
     default: ''
     required: false
-  branch:
+  target-branch:
     description: 'A separate branch to perform the version bump on'
     default: ''
     required: false

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'Custom dir to the package'
     default: ''
     required: false
+  branch:
+    description: 'A separate branch to perform the version bump on'
+    default: ''
+    required: false
   default:
     description: 'Set a default version bump to use'
     default: 'patch'

--- a/index.js
+++ b/index.js
@@ -78,8 +78,9 @@ Toolkit.run(async tools => {
       currentBranch = process.env.GITHUB_HEAD_REF
       isPullRequest = true
     }
-    if (process.env['INPUT_TAG-BRANCH']) {
-      currentBranch = process.env['INPUT_TAG-BRANCH']
+    if (process.env['INPUT_TARGET-BRANCH']) {
+      // We want to override the branch that we are pulling / pushing to
+      currentBranch = process.env['INPUT_TARGET-BRANCH']
     }
     console.log('currentBranch:', currentBranch)
     // do it in the current checked out github branch (DETACHED HEAD)

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ Toolkit.run(async tools => {
   const majorWords = process.env['INPUT_MAJOR-WORDING'].split(',')
   const minorWords = process.env['INPUT_MINOR-WORDING'].split(',')
   const preReleaseWords = process.env['INPUT_RC-WORDING'].split(',')
-  
+
   // if patch words aren't specified, any commit message qualifies as a patch
   const patchWords = process.env['INPUT_PATCH-WORDING'] ? process.env['INPUT_PATCH-WORDING'].split(',') : null
 
@@ -77,6 +77,9 @@ Toolkit.run(async tools => {
       // Comes from a pull request
       currentBranch = process.env.GITHUB_HEAD_REF
       isPullRequest = true
+    }
+    if (process.env['INPUT_TAG-BRANCH']) {
+      currentBranch = process.env['INPUT_TAG-BRANCH']
     }
     console.log('currentBranch:', currentBranch)
     // do it in the current checked out github branch (DETACHED HEAD)


### PR DESCRIPTION
Hello, I'd like to be able to run this action on tag, but I'm getting an error of 

```
✖  fatal     Error: Command failed: git checkout 0.0.0 
error: pathspec '0.0.0' did not match any file(s) known to git.
```

I figured the easiest way is to add the ability to specify which (other) branch the version increment should be performed on.