### PR TITLE
Changed condition for autobumping version

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ Toolkit.run(async tools => {
   const commitMessage = 'version bump to'
   console.log('messages:', messages)
   const isVersionBump = messages.map(message => message.toLowerCase().includes(commitMessage)).includes(true)
-  if (isVersionBump) {
+  if (!isVersionBump) {
     tools.exit.success('No action necessary!')
     return
   }


### PR DESCRIPTION
### Description

In the current version, if we input the string "version bump to" in the commit message then the version will not be bumped. But if we input only "major" or "minor" keywords then it will update the version. Currently, the use of the `isVersionBump` variable is not justifying its name. So I changed the condition, which makes sense to the `isVersionBump` variable's name.

### Output

By this change, the commit message must contain the "version bump to" string otherwise it will not update the version. 