### PR TITLE
Custom commit message option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,13 @@ Make sure you use the `actions/checkout@v2` action!
   with:
     target-branch: 'master'
 ```
+
+**commit-message:** Set a custom commit message for version bump commit. Useful for skipping additional workflows run on push. Example:
+```yaml
+- name:  'Automated Version Bump'
+  uses:  'phips28/gh-action-bump-version@master'
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    commit-message: 'CI: bumps version to {{version}} [skip ci]'
+```

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: 'Set a default version bump to use'
     default: 'patch'
     required: false
+  commit-message:
+    description: 'Set a custom commit message for version bump commit'
+    deafult: ''
+    required: false
 outputs:
   newTag:
     description: 'The newly created tag'

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
     required: false
   commit-message:
     description: 'Set a custom commit message for version bump commit'
-    deafult: ''
+    default: ''
     required: false
 outputs:
   newTag:

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ Toolkit.run(async tools => {
 
   const commitMessage = process.env['INPUT_COMMIT-MESSAGE'] || 'ci: version bump to {{version}}'
   console.log('messages:', messages)
-  const commitMessageRegex = new RegExp(commitMessage.replace('{{version}}', 'v\d\.\d\.\d'), 'ig');
+  const commitMessageRegex = new RegExp(commitMessage.replace(/{{version}}/g, 'v\d\.\d\.\d'), 'ig');
   const isVersionBump = messages.find(message => commitMessageRegex.test(message)) !== undefined
 
   if (isVersionBump) {
@@ -91,7 +91,7 @@ Toolkit.run(async tools => {
       ['version', '--allow-same-version=true', '--git-tag-version=false', current])
     console.log('current:', current, '/', 'version:', version)
     let newVersion = execSync(`npm version --git-tag-version=false ${version}`).toString().trim()
-    await tools.runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace('{{version}}', newVersion)])
+    await tools.runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)])
 
     // now go to the actual branch to perform the same versioning
     if (isPullRequest) {
@@ -108,7 +108,7 @@ Toolkit.run(async tools => {
     console.log(`::set-output name=newTag::${newVersion}`)
     try {
       // to support "actions/checkout@v1"
-      await tools.runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace('{{version}}', newVersion)])
+      await tools.runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)])
     } catch (e) {
       console.warn('git commit failed because you are using "actions/checkout@v2"; ' +
         'but that doesnt matter because you dont need that git commit, thats only for "actions/checkout@v1"')

--- a/index.js
+++ b/index.js
@@ -18,9 +18,11 @@ Toolkit.run(async tools => {
 
   const messages = event.commits ? event.commits.map(commit => commit.message + '\n' + commit.body) : []
 
-  const commitMessage = 'version bump to'
+  const commitMessage = process.env['INPUT_COMMIT-MESSAGE'] || 'ci: version bump to {{version}}'
   console.log('messages:', messages)
-  const isVersionBump = messages.map(message => message.toLowerCase().includes(commitMessage)).includes(true)
+  const commitMessageRegex = new RegExp(commitMessage.replace('{{version}}', 'v\d\.\d\.\d'), 'ig');
+  const isVersionBump = messages.find(message => commitMessageRegex.test(message)) !== undefined
+
   if (isVersionBump) {
     tools.exit.success('No action necessary!')
     return
@@ -89,7 +91,7 @@ Toolkit.run(async tools => {
       ['version', '--allow-same-version=true', '--git-tag-version=false', current])
     console.log('current:', current, '/', 'version:', version)
     let newVersion = execSync(`npm version --git-tag-version=false ${version}`).toString().trim()
-    await tools.runInWorkspace('git', ['commit', '-a', '-m', `ci: ${commitMessage} ${newVersion}`])
+    await tools.runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace('{{version}}', newVersion)])
 
     // now go to the actual branch to perform the same versioning
     if (isPullRequest) {
@@ -106,7 +108,7 @@ Toolkit.run(async tools => {
     console.log(`::set-output name=newTag::${newVersion}`)
     try {
       // to support "actions/checkout@v1"
-      await tools.runInWorkspace('git', ['commit', '-a', '-m', `ci: ${commitMessage} ${newVersion}`])
+      await tools.runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace('{{version}}', newVersion)])
     } catch (e) {
       console.warn('git commit failed because you are using "actions/checkout@v2"; ' +
         'but that doesnt matter because you dont need that git commit, thats only for "actions/checkout@v1"')


### PR DESCRIPTION
fixes #27 

Thanks for providing this action! Started using this recently and found the need for some additional functionality that an issue had been created for. Also, it appears gh has addressed it's limitations as well:

https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
