### PR TITLE
feat: Support different commit message on tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,14 @@ Make sure you use the `actions/checkout@v2` action!
   with:
     commit-message: 'CI: bumps version to {{version}} [skip ci]'
 ```
+
+**tag-commit-message:** Set a custom commit message for the tag commit. Useful for triggering workflows on tag events when [skip-ci] is used on the original commit
+```yaml
+- name:  'Automated Version Bump'
+  uses:  'phips28/gh-action-bump-version@master'
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    commit-message: 'CI: bumps version to {{version}} [skip ci]'
+    tag-commit-message: 'CI: bumps version to {{version}}'
+```

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,10 @@ inputs:
     description: 'Set a custom commit message for version bump commit'
     default: ''
     required: false
+  tag-commit-message:
+    description: 'Set a custom commit message for tag commit'
+    default: ''
+    required: false
 outputs:
   newTag:
     description: 'The newly created tag'


### PR DESCRIPTION
Resolves #85. I've tested that the `git show <tag-name>` command displays the new commit message