### PR TITLE
Fixes to include all options - MAJOR, MINOR, PATCH, PRE-RELEASE

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ Toolkit.run(async (tools) => {
 
   const majorWords = process.env['INPUT_MAJOR-WORDING'].split(',');
   const minorWords = process.env['INPUT_MINOR-WORDING'].split(',');
-  const preReleaseWords = process.env['INPUT_RC-WORDING'].split(',');
   const patchWords = process.env['INPUT_PATCH-WORDING'].split(',');
+  const preReleaseWords = process.env['INPUT_RC-WORDING'].split(',');
 
   let version = process.env.INPUT_DEFAULT;
   let foundWord = null;
@@ -48,6 +48,9 @@ Toolkit.run(async (tools) => {
   } else if (messages.some((message) => minorWords.some((word) => message.includes(word)))) {
     version = 'minor';
     tools.log('Version is set to minor');
+  } else if (messages.some((message) => patchWords.some((word) => message.includes(word)))) {
+    version = 'patch';
+    tools.log('Version is set to patch');
   } else if (
     messages.some((message) =>
       preReleaseWords.some((word) => {
@@ -63,16 +66,6 @@ Toolkit.run(async (tools) => {
     preid = foundWord.split('-')[1];
     version = 'prerelease';
     tools.log('Version is set to prerelease2');
-  } else if (Array.isArray(patchWords) && patchWords.length) {
-    tools.log('PatchWords is set : ' + patchWords);
-    if (!messages.some((message) => patchWords.some((word) => message.includes(word)))) {
-      tools.log('Messages found on the patchwords : ' + messages);
-      version = null;
-      tools.log('Version is set to null 2');
-    }
-  } else if (process.env.INPUT_DEFAULT === 'prerelease'){
-    tools.log('Version is set to prerelease');
-    version = 'prerelease';
   }
 
   // case: if default=prerelease, but rc-wording is also set
@@ -81,12 +74,12 @@ Toolkit.run(async (tools) => {
   tools.log(version); // null
   tools.log('PreID: ' + preid); //prc
   tools.log(process.env.INPUT_DEFAULT);
-  if (version === 'prerelease' && !messages.some((message) => preReleaseWords.some((word) => message.includes(word)))) {
-    tools.log('Version is set to null');
-    version = null;
-  }
+  // if (version === 'prerelease' && !messages.some((message) => preReleaseWords.some((word) => message.includes(word)))) {
+  //   tools.log('Version is set to null');
+  //   version = null;
+  // }
 
-  if (version === 'prerelease' || process.env.INPUT_DEFAULT === 'prerelease' && preid) {
+  if (version === 'prerelease' || (process.env.INPUT_DEFAULT === 'prerelease' && preid)) {
     tools.log('Version is prerelease and it contains a preid');
     version = 'prerelease';
     version = `${version} --preid=${preid}`;

--- a/index.js
+++ b/index.js
@@ -28,26 +28,36 @@ Toolkit.run(async (tools) => {
     return;
   }
 
+  // input wordings for MAJOR, MINOR, PATCH, PRE-RELEASE
   const majorWords = process.env['INPUT_MAJOR-WORDING'].split(',');
   const minorWords = process.env['INPUT_MINOR-WORDING'].split(',');
   const patchWords = process.env['INPUT_PATCH-WORDING'].split(',');
   const preReleaseWords = process.env['INPUT_RC-WORDING'].split(',');
 
+  // get default version bump
   let version = process.env.INPUT_DEFAULT;
   let foundWord = null;
+  // get the pre-release prefix specified in action
   let preid = process.env.INPUT_PREID;
 
+  // case: if wording for MAJOR found
   if (
     messages.some(
       (message) => /^([a-zA-Z]+)(\(.+\))?(\!)\:/.test(message) || majorWords.some((word) => message.includes(word)),
     )
   ) {
     version = 'major';
-  } else if (messages.some((message) => minorWords.some((word) => message.includes(word)))) {
+  }
+  // case: if wording for MINOR found
+  else if (messages.some((message) => minorWords.some((word) => message.includes(word)))) {
     version = 'minor';
-  } else if (messages.some((message) => patchWords.some((word) => message.includes(word)))) {
+  }
+  // case: if wording for PATCH found
+  else if (messages.some((message) => patchWords.some((word) => message.includes(word)))) {
     version = 'patch';
-  } else if (
+  }
+  // case: if wording for PRE-RELEASE found
+  else if (
     messages.some((message) =>
       preReleaseWords.some((word) => {
         if (message.includes(word)) {
@@ -63,16 +73,25 @@ Toolkit.run(async (tools) => {
     version = 'prerelease';
   }
 
+  // case: if default=prerelease, but rc-wording is also set
+  // then unset it and do not run, when no rc words found in message
+  if (version === 'prerelease' && !messages.some((message) => preReleaseWords.some((word) => message.includes(word)))) {
+    version = null;
+  }
+
+  // case: if default=prerelease, but rc-wording is NOT set
   if (version === 'prerelease' && preid) {
     version = 'prerelease';
     version = `${version} --preid=${preid}`;
   }
 
+  // case: if nothing of the above matches
   if (version === null) {
     tools.exit.success('No version keywords found, skipping bump.');
     return;
   }
 
+  // GIT logic
   try {
     const current = pkg.version.toString();
     // set git user

--- a/index.js
+++ b/index.js
@@ -73,6 +73,8 @@ Toolkit.run(async (tools) => {
     version = 'prerelease';
   }
 
+  tools.log('preReleaseWords - ' + preReleaseWords)
+
   // case: if default=prerelease,
   // rc-wording is also set
   // and does not include any of rc-wording

--- a/index.js
+++ b/index.js
@@ -37,20 +37,16 @@ Toolkit.run(async (tools) => {
   let foundWord = null;
   let preid = process.env.INPUT_PREID;
 
-  tools.log('Version is set to Begining: ' + version);
   if (
     messages.some(
       (message) => /^([a-zA-Z]+)(\(.+\))?(\!)\:/.test(message) || majorWords.some((word) => message.includes(word)),
     )
   ) {
     version = 'major';
-    tools.log('Version is set to major');
   } else if (messages.some((message) => minorWords.some((word) => message.includes(word)))) {
     version = 'minor';
-    tools.log('Version is set to minor');
   } else if (messages.some((message) => patchWords.some((word) => message.includes(word)))) {
     version = 'patch';
-    tools.log('Version is set to patch');
   } else if (
     messages.some((message) =>
       preReleaseWords.some((word) => {
@@ -65,22 +61,9 @@ Toolkit.run(async (tools) => {
   ) {
     preid = foundWord.split('-')[1];
     version = 'prerelease';
-    tools.log('Version is set to prerelease2');
   }
 
-  // case: if default=prerelease, but rc-wording is also set
-  // then unset it and do not run, when no rc words found in message
-  tools.log('Before Login');
-  tools.log(version); // null
-  tools.log('PreID: ' + preid); //prc
-  tools.log(process.env.INPUT_DEFAULT);
-  // if (version === 'prerelease' && !messages.some((message) => preReleaseWords.some((word) => message.includes(word)))) {
-  //   tools.log('Version is set to null');
-  //   version = null;
-  // }
-
   if (version === 'prerelease' && preid) {
-    tools.log('Version is prerelease and it contains a preid');
     version = 'prerelease';
     version = `${version} --preid=${preid}`;
   }

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ Toolkit.run(async (tools) => {
   tools.log(version); // null
   tools.log('PreID: ' + preid); //prc
   tools.log(process.env.INPUT_DEFAULT);
-  if (version === 'prerelease' && !messages.some((message) => preReleaseWords.some((word) => message.includes(word))) && process.env.INPUT_DEFAULT != 'prerelease') {
+  if (version === 'prerelease' && !messages.some((message) => preReleaseWords.some((word) => message.includes(word)))) {
     tools.log('Version is set to null');
     version = null;
   }

--- a/index.js
+++ b/index.js
@@ -44,8 +44,10 @@ Toolkit.run(async (tools) => {
     )
   ) {
     version = 'major';
+    tools.log('Version is set to major');
   } else if (messages.some((message) => minorWords.some((word) => message.includes(word)))) {
     version = 'minor';
+    tools.log('Version is set to minor');
   } else if (
     messages.some((message) =>
       preReleaseWords.some((word) => {
@@ -60,19 +62,22 @@ Toolkit.run(async (tools) => {
   ) {
     preid = foundWord.split('-')[1];
     version = 'prerelease';
+    tools.log('Version is set to prerelease2');
   } else if (Array.isArray(patchWords) && patchWords.length) {
     if (!messages.some((message) => patchWords.some((word) => message.includes(word)))) {
       version = null;
+      tools.log('Version is set to null 2');
     }
   } else if (process.env.INPUT_DEFAULT === 'prerelease'){
+    tools.log('Version is set to prerelease');
     version = 'prerelease';
   }
 
   // case: if default=prerelease, but rc-wording is also set
   // then unset it and do not run, when no rc words found in message
   tools.log('Before Login');
-  tools.log(version);
-  tools.log('PreID: ' + preid);
+  tools.log(version); // null
+  tools.log('PreID: ' + preid); //prc
   tools.log(process.env.INPUT_DEFAULT);
   if (version === 'prerelease' && !messages.some((message) => preReleaseWords.some((word) => message.includes(word))) && process.env.INPUT_DEFAULT != 'prerelease') {
     tools.log('Version is set to null');

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ Toolkit.run(async (tools) => {
 
   // case: if default=prerelease, but rc-wording is also set
   // then unset it and do not run, when no rc words found in message
-  if (version === 'prerelease' && !messages.some((message) => preReleaseWords.some((word) => message.includes(word)))) {
+  if (version === 'prerelease' && !messages.some((message) => preReleaseWords.some((word) => message.includes(word))) && process.env.INPUT_DEFAULT != 'prerelease') {
     version = null;
   }
 

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ Toolkit.run(async (tools) => {
   //   version = null;
   // }
 
-  if (version === 'prerelease' && preid)) {
+  if (version === 'prerelease' && preid) {
     tools.log('Version is prerelease and it contains a preid');
     version = 'prerelease';
     version = `${version} --preid=${preid}`;

--- a/index.js
+++ b/index.js
@@ -73,9 +73,11 @@ Toolkit.run(async (tools) => {
     version = 'prerelease';
   }
 
-  // case: if default=prerelease, but rc-wording is also set
-  // then unset it and do not run, when no rc words found in message
-  if (version === 'prerelease' && !messages.some((message) => preReleaseWords.some((word) => message.includes(word)))) {
+  // case: if default=prerelease,
+  // rc-wording is also set
+  // and does not include any of rc-wording
+  // then unset it and do not run
+  if (version === 'prerelease' && preReleaseWords !== '' && !messages.some((message) => preReleaseWords.some((word) => message.includes(word)))) {
     version = null;
   }
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,8 @@ Toolkit.run(async (tools) => {
   let version = process.env.INPUT_DEFAULT;
   let foundWord = null;
   let preid = process.env.INPUT_PREID;
+
+  tools.log('Version is set to Begining: ' + version);
   if (
     messages.some(
       (message) => /^([a-zA-Z]+)(\(.+\))?(\!)\:/.test(message) || majorWords.some((word) => message.includes(word)),
@@ -62,7 +64,9 @@ Toolkit.run(async (tools) => {
     version = 'prerelease';
     tools.log('Version is set to prerelease2');
   } else if (Array.isArray(patchWords) && patchWords.length) {
+    tools.log('PatchWords is set : ' + patchWords);
     if (!messages.some((message) => patchWords.some((word) => message.includes(word)))) {
+      tools.log('Messages found on the patchwords : ' + messages);
       version = null;
       tools.log('Version is set to null 2');
     }
@@ -82,7 +86,7 @@ Toolkit.run(async (tools) => {
     version = null;
   }
 
-  if (version === 'prerelease' && preid) {
+  if (version === 'prerelease' || process.env.INPUT_DEFAULT === 'prerelease' && preid) {
     tools.log('Version is prerelease and it contains a preid');
     version = `${version} --preid=${preid}`;
   }

--- a/index.js
+++ b/index.js
@@ -31,9 +31,7 @@ Toolkit.run(async (tools) => {
   const majorWords = process.env['INPUT_MAJOR-WORDING'].split(',');
   const minorWords = process.env['INPUT_MINOR-WORDING'].split(',');
   const preReleaseWords = process.env['INPUT_RC-WORDING'].split(',');
-
-  // if patch words aren't specified, any commit message qualifies as a patch
-  const patchWords = process.env['INPUT_PATCH-WORDING'] ? process.env['INPUT_PATCH-WORDING'].split(',') : null;
+  const patchWords = process.env['INPUT_PATCH-WORDING'].split(',');
 
   let version = process.env.INPUT_DEFAULT;
   let foundWord = null;

--- a/index.js
+++ b/index.js
@@ -68,11 +68,17 @@ Toolkit.run(async (tools) => {
 
   // case: if default=prerelease, but rc-wording is also set
   // then unset it and do not run, when no rc words found in message
+  tools.log('Before Login');
+  tools.log(version);
+  tools.log('PreID: ' + preid);
+  tools.log(process.env.INPUT_DEFAULT);
   if (version === 'prerelease' && !messages.some((message) => preReleaseWords.some((word) => message.includes(word))) && process.env.INPUT_DEFAULT != 'prerelease') {
+    tools.log('Version is set to null');
     version = null;
   }
 
   if (version === 'prerelease' && preid) {
+    tools.log('Version is prerelease and it contains a preid');
     version = `${version} --preid=${preid}`;
   }
 

--- a/index.js
+++ b/index.js
@@ -64,6 +64,8 @@ Toolkit.run(async (tools) => {
     if (!messages.some((message) => patchWords.some((word) => message.includes(word)))) {
       version = null;
     }
+  } else if (process.env.INPUT_DEFAULT === 'prerelease'){
+    version = 'prerelease';
   }
 
   // case: if default=prerelease, but rc-wording is also set

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ Toolkit.run(async (tools) => {
   //   version = null;
   // }
 
-  if (version === 'prerelease' || (process.env.INPUT_DEFAULT === 'prerelease' && preid)) {
+  if (version === 'prerelease' && preid)) {
     tools.log('Version is prerelease and it contains a preid');
     version = 'prerelease';
     version = `${version} --preid=${preid}`;

--- a/index.js
+++ b/index.js
@@ -88,6 +88,7 @@ Toolkit.run(async (tools) => {
 
   if (version === 'prerelease' || process.env.INPUT_DEFAULT === 'prerelease' && preid) {
     tools.log('Version is prerelease and it contains a preid');
+    version = 'prerelease';
     version = `${version} --preid=${preid}`;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-action-bump-version",
-  "version": "8.2.15",
+  "version": "8.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/phips28/gh-action-bump-version.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-action-bump-version",
-  "version": "8.2.14",
+  "version": "8.2.15",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/phips28/gh-action-bump-version.git"


### PR DESCRIPTION
In my case, I wanted to cover the scenarios for all semver options - MAJOR, MINOR, PATCH, PRERELEASE.

I am using the below action config in my project:
![image](https://user-images.githubusercontent.com/5765285/124175246-0e139700-dab6-11eb-9a4b-d35d77fb13d5.png)

The reason why I am defining `rc-wording: ''` is because even tho I am setting the `default: prerelease` and none of the `minor-wording, major-wording, patch-wording` matches, there is a default message for rc-wording
![image](https://user-images.githubusercontent.com/5765285/124175407-3f8c6280-dab6-11eb-906e-6851299fdced.png)

If the above are not included in the commit message, version bump is skipped.

I also added some comments for future contributors.