### PR TITLE
refactor : solve preid issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,9 @@ Toolkit.run(async (tools) => {
       }),
     )
   ) {
-    preid = foundWord.split('-')[1];
+    if (foundWord != ''){
+      preid = foundWord.split('-')[1];
+    } 
     version = 'prerelease';
   }
 


### PR DESCRIPTION
When set default to prerelease and set some preid word it wasn't working as expected because it was making preid undefined so I put simple if statement to check foundword is empty or not and solved the issue