### PR TITLE
Publish Docker image to allow users the ability to pull a container in Github actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -52,7 +52,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: thequeenisdead/gh-action-bump-version:latest
+          images: thequeenisdead/gh-action-bump-version
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -34,3 +34,30 @@ jobs:
         env:
           NEW_TAG: ${{ steps.version-bump.outputs.newTag }}
         run: echo "new tag $NEW_TAG"
+
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: thequeenisdead/gh-action-bump-version:latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -52,7 +52,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: thequeenisdead/gh-action-bump-version
+          images: phips28/gh-action-bump-version
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/README.md
+++ b/README.md
@@ -23,7 +23,29 @@ Make sure you use the `actions/checkout@v2` action!
 * Push the bumped npm version in package.json back into the repo.
 * Push a tag for the new version back into the repo.
 
+
 ### Usage:
+
+## Docker 
+
+You can choose to build the image each time you run this action by using the 'native' GitHub actions `uses:` statement
+like the examples found below in Action Options.
+
+You can also opt to skip building, and instead pull the image directly from DockerHub using a slightly modified version
+of the `uses:` statement 
+
+```yaml
+      - name: 'Automated Version Bump'
+        id: version-bump
+        uses: 'docker://phips28/gh-action-bump-version:master'
+        with:
+          tag-prefix: 'v'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Action Options
+
 **tag-prefix:** Prefix that is used for the git tag  (optional). Example:
 ```yaml
 - name:  'Automated Version Bump'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-action-bump-version",
-  "version": "8.3.4",
+  "version": "8.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-action-bump-version",
-  "version": "8.3.4",
+  "version": "8.3.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/phips28/gh-action-bump-version.git"


### PR DESCRIPTION
In response to [this StackOverflow question](https://stackoverflow.com/questions/64174918/github-actions-docker-caching/68676939#68676939) and https://github.com/phips28/gh-action-bump-version/issues/42, publishing a Docker image for users of this action will allow them to directly pull the image instead of having to build the source code each time. This reduces the time to prepare the action from ~30 seconds to ~8

To enable this change to work, you will have to create a new repository in DockerHub, and add your username and password to the Secrets configuration in GitHub

It's worth noting that you can publish an image to the GitHub repository if you wish, and the instructions for that can be found here:
https://docs.github.com/en/actions/guides/publishing-docker-images

To view an example of what this change enables, please see the changes made in this PR in conjunction with the [DockerHub image](https://hub.docker.com/repository/docker/thequeenisdead/gh-action-bump-version), and an example use case:

Example Usage: https://github.com/TheQueenIsDead/action-caching/blob/main/.github/workflows/push.yml
Example Repo Workflow: https://github.com/TheQueenIsDead/action-caching/runs/3259818711?check_suite_focus=true
(Please be aware the example workflow failed, but after the fact, and seemingly due to the fact that my commit message includes characters that are perhaps not being handled. The `Setup Job` and `Pull thequeenisdead/gh-action-bump-version` steps are the most important things to look at)