### PR TITLE
Allow updating npm lockfile v2 with the new version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,10 @@ inputs:
     description: 'Set to false to skip pushing the new tag'
     default: 'true'
     required: false
+  bump_package-lock:
+    description: 'Set to false to skip bumping version in lockfile version 2'
+    default: 'true'
+    required: false
 outputs:
   newTag:
     description: 'The newly created tag'

--- a/index.js
+++ b/index.js
@@ -160,8 +160,7 @@ const workspace = process.env.GITHUB_WORKSPACE;
 
     // case: when user wants to skip updating package-lock.json v2
     try {
-      const bumpPackageLock = process.env['INPUT_BUMP_PACKAGE-LOCK']
-      if (bumpPackageLock) {
+      if (process.env['INPUT_BUMP_PACKAGE-LOCK'] === 'true') {
         await runInWorkspace('npm', ['install', '--package-lock-only', '--ignore-scripts'])
       }
     } catch(e) {

--- a/index.js
+++ b/index.js
@@ -157,6 +157,17 @@ const workspace = process.env.GITHUB_WORKSPACE;
     newVersion = execSync(`npm version --git-tag-version=false ${version}`).toString().trim().replace(/^v/, '');
     newVersion = `${tagPrefix}${newVersion}`;
     console.log(`::set-output name=newTag::${newVersion}`);
+
+    // case: when user wants to skip updating package-lock.json v2
+    try {
+      const bumpPackageLock = process.env['INPUT_BUMP_PACKAGE-LOCK']
+      if (bumpPackageLock) {
+        await runInWorkspace('npm', ['install', '--package-lock-only', '--ignore-scripts'])
+      }
+    } catch(e) {
+      logError(e);
+    }
+
     try {
       // to support "actions/checkout@v1"
       await runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);


### PR DESCRIPTION
Hey @phips28 

This is a draft PR and I didn't even test it, but can you help me with testing it?

# Description

re #81 

The aim of this PR is to support updating `package-lock.json` together with the `package.json`

`lockfileVesion: 2` adds the info about the version in `package-lock.json` - to check it out please try to run `npm i` with npm@7 in this repo, you'll get something like this 

![img](https://user-images.githubusercontent.com/1291032/135908015-5390de17-a7b5-42ed-8f2b-d02f6fe93623.png)

Package version in package.json and package-lock.json is different.

The goal of this PR is to update version in package-lock.json together with the version in package.json.
Basically you can run npm script that doesn't compare node_modules with package-lock.json and updates package-lock.json with the new version from package.json 