### PR TITLE
Revert "Allow updating npm lockfile v2 with the new version"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,10 +54,6 @@ inputs:
     description: 'Set to false to skip pushing the new tag'
     default: 'true'
     required: false
-  bump_package-lock:
-    description: 'Set to false to skip bumping version in lockfile version 2'
-    default: 'true'
-    required: false
 outputs:
   newTag:
     description: 'The newly created tag'

--- a/index.js
+++ b/index.js
@@ -158,16 +158,6 @@ const workspace = process.env.GITHUB_WORKSPACE;
     newVersion = execSync(`npm version --git-tag-version=false ${version}`).toString().trim().replace(/^v/, '');
     newVersion = `${tagPrefix}${newVersion}`;
     console.log(`::set-output name=newTag::${newVersion}`);
-
-    // case: when user wants to skip updating package-lock.json v2
-    try {
-      if (process.env['INPUT_BUMP_PACKAGE-LOCK'] === 'true') {
-        await runInWorkspace('npm', ['install', '--package-lock-only', '--ignore-scripts'])
-      }
-    } catch(e) {
-      logError(e);
-    }
-
     try {
       // to support "actions/checkout@v1"
       await runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);


### PR DESCRIPTION
Reverts phips28/gh-action-bump-version#132

This will not work with the latest version with node12. (v9)