### PR TITLE
Added option to skip commit after a bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ Remove the 'actions/setup-node@v1' step from your action.yml file
     skip-tag:  'true'
 ```
 
+**skip-commit:** No commit is made after the version is bumped  (optional). Example:
+```yaml
+- name:  'Automated Version Bump'
+  uses:  'phips28/gh-action-bump-version@master'
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    skip-commit:  'true'
+```
+
 **default:** Set a default version bump to use  (optional - defaults to patch). Example:
 ```yaml
 - name:  'Automated Version Bump'

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: 'Avoid to add a TAG to the version update commit'
     default: 'false'
     required: false
+  skip-commit:
+    description: 'Avoid to add a commit after the version is bumped'
+    default: 'false'
+    required: false
   PACKAGEJSON_DIR:
     description: 'Custom dir to the package'
     default: ''

--- a/index.js
+++ b/index.js
@@ -146,7 +146,9 @@ const workspace = process.env.GITHUB_WORKSPACE;
     console.log('current:', current, '/', 'version:', version);
     let newVersion = execSync(`npm version --git-tag-version=false ${version}`).toString().trim().replace(/^v/, '');
     newVersion = `${tagPrefix}${newVersion}`;
-    await runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);
+    if (process.env['INPUT_SKIP-COMMIT'] !== 'true') {
+      await runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);
+    }
 
     // now go to the actual branch to perform the same versioning
     if (isPullRequest) {
@@ -161,7 +163,9 @@ const workspace = process.env.GITHUB_WORKSPACE;
     console.log(`::set-output name=newTag::${newVersion}`);
     try {
       // to support "actions/checkout@v1"
-      await runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);
+      if (process.env['INPUT_SKIP-COMMIT'] !== 'true') {
+        await runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);
+      }
     } catch (e) {
       console.warn(
         'git commit failed because you are using "actions/checkout@v2"; ' +

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "9.0.7",
+      "name": "gh-action-bump-version",
+      "version": "9.0.10",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^27.0.1",

--- a/tests/end-to-end/config.yaml
+++ b/tests/end-to-end/config.yaml
@@ -155,6 +155,27 @@ suites:
         expected:
           version: 4.1.3
           branch: other-branch
+  - name: skip-commit
+    yaml:
+      name: Bump Version (Skip Commit)
+      on:
+        push:
+      jobs:
+        bump-version:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v2
+            - id: version-bump
+              uses: ./action
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                skip-commit: true
+    tests:
+      - message: no keywords
+        expected:
+          version: 4.1.4
+          message: 'ci: version bump to 4.1.3'
 
 actionFiles:
   - index.js


### PR DESCRIPTION
Fixes #138.

Added a `skip-commit: boolean` option, that prevent doing a `git commit` after the version is bumped.

Also, do not hesitate to suggest better wording, on the documentation of this new option.

I've tried to add tests, but unfortunately I wasn't able to run them locally (all are failing, even from the latest version, without modifying anything). I might miss something, and help is wanted for that :nerd_face:.
Other than that, this new option is working well (tested on a project I'm working on).