### PR TITLE
Implement flag "skip-push", deprecate flag "push"

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The tag is not added to the git repository  (optional). Example:
 ```
 
 #### **skip-commit:**
-No commit is made after the version is bumped  (optional). Example:
+No commit is made after the version is bumped (optional). Must be used in combination with `skip-tag`, since if there's no commit, there's nothing to tag. Example:
 ```yaml
 - name:  'Automated Version Bump'
   uses:  'phips28/gh-action-bump-version@master'
@@ -104,8 +104,19 @@ No commit is made after the version is bumped  (optional). Example:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
     skip-commit:  'true'
+    skip-tag: 'true'
 ```
 
+#### **skip-push:**
+If true, skip pushing any commits or tags created after the version bump (optional). Example:
+```yaml
+- name:  'Automated Version Bump'
+  uses:  'phips28/gh-action-bump-version@master'
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    skip-push:  'true'
+```
 
 #### **PACKAGEJSON_DIR:**
 Param to parse the location of the desired package.json (optional). Example:
@@ -139,8 +150,8 @@ Set a custom commit message for version bump commit. Useful for skipping additio
     commit-message: 'CI: bumps version to {{version}} [skip ci]'
 ```
 
-#### **push:**
-Set false you want to avoid pushing the new version tag/package.json. Example:
+#### [DEPRECATED] **push:**
+**DEPRECATED** Set false you want to avoid pushing the new version tag/package.json. Example:
 ```yaml
 - name:  'Automated Version Bump'
   uses:  'phips28/gh-action-bump-version@master'

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
     default: 'false'
     required: false
   skip-push:
-    description: 'Skip pushing the commit with the version bump'
+    description: 'If true, skip pushing any commits or tags created after the version bump'
     default: false
     required: false
   PACKAGEJSON_DIR:

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: 'Avoid to add a commit after the version is bumped'
     default: 'false'
     required: false
+  skip-push:
+    description: 'Skip pushing the commit with the version bump'
+    default: false
+    required: false
   PACKAGEJSON_DIR:
     description: 'Custom dir to the package'
     default: ''
@@ -55,7 +59,7 @@ inputs:
     default: ''
     required: false
   push:
-    description: 'Set to false to skip pushing the new tag'
+    description: '[DEPRECATED] Set to false to skip pushing the new tag'
     default: 'true'
     required: false
 outputs:

--- a/index.js
+++ b/index.js
@@ -181,7 +181,6 @@ const workspace = process.env.GITHUB_WORKSPACE;
         await runInWorkspace('git', ['push', remoteRepo, '--tags']);
       }
     } else {
-      // skip-tag: true, so we push without pushing tags.
       if (process.env['INPUT_SKIP-PUSH'] !== 'true') {
         await runInWorkspace('git', ['push', remoteRepo]);
       }

--- a/index.js
+++ b/index.js
@@ -176,10 +176,15 @@ const workspace = process.env.GITHUB_WORKSPACE;
     const remoteRepo = `https://${process.env.GITHUB_ACTOR}:${process.env.GITHUB_TOKEN}@github.com/${process.env.GITHUB_REPOSITORY}.git`;
     if (process.env['INPUT_SKIP-TAG'] !== 'true') {
       await runInWorkspace('git', ['tag', newVersion]);
-      await runInWorkspace('git', ['push', remoteRepo, '--follow-tags']);
-      await runInWorkspace('git', ['push', remoteRepo, '--tags']);
+      if (process.env['INPUT_SKIP-PUSH'] !== 'true') {
+        await runInWorkspace('git', ['push', remoteRepo, '--follow-tags']);
+        await runInWorkspace('git', ['push', remoteRepo, '--tags']);
+      }
     } else {
-      await runInWorkspace('git', ['push', remoteRepo]);
+      // skip-tag: true, so we push without pushing tags.
+      if (process.env['INPUT_SKIP-PUSH'] !== 'true') {
+        await runInWorkspace('git', ['push', remoteRepo]);
+      }
     }
   } catch (e) {
     logError(e);


### PR DESCRIPTION
- Implements a new input flag `skip-push`, default false. If true, skips pushing any commit or tag created during the version bump.
- Deprecates the input flag `push`, which was documented as skipping the push, but whose actual behavior is to skip all operations (version bump in package.json, git commit, git tag, git push). In a future major version, this flag could be renamed to `no-op`, or even just removed since its behavior can be achieved using the `if: ` conditionals in Github Actions anyway.

Tested using the end-to-end test suite (needed some modifications before it would run), over here: https://github.com/rosshamish/gh-action-bump-version/pull/1/checks