### PR TITLE
Feature: bump-policy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,23 @@ Set a custom commit message for version bump commit. Useful for skipping additio
     commit-message: 'CI: bumps version to {{version}} [skip ci]'
 ```
 
+#### **bump-policy:**
+Set version bump ignore policy. Useful for pull requests between branches with version bumps. Options are as follows:
+
+* `'all'` (default): checks all commit messages and skips bump if any previous bumps found
+* `'ignore'`: always bump regardless of whether bumps included in commit messages
+* `'last-commit'`: bump if last commit was not version bump
+
+Example:
+```yaml
+- name:  'Automated Version Bump'
+  uses:  'phips28/gh-action-bump-version@master'
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    bump-policy: 'ignore'
+```
+
 #### [DEPRECATED] **push:**
 **DEPRECATED** Set false you want to avoid pushing the new version tag/package.json. Example:
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,10 @@ inputs:
     description: 'Set a custom commit message for version bump commit'
     default: ''
     required: false
+  bump-policy:
+    description: 'Set version bump ignore policy'
+    default: 'all'
+    required: false
   push:
     description: '[DEPRECATED] Set to false to skip pushing the new tag'
     default: 'true'

--- a/index.js
+++ b/index.js
@@ -25,8 +25,21 @@ const workspace = process.env.GITHUB_WORKSPACE;
 
   const commitMessage = process.env['INPUT_COMMIT-MESSAGE'] || 'ci: version bump to {{version}}';
   console.log('commit messages:', messages);
+
+  const bumpPolicy = process.env['INPUT_BUMP-POLICY'] || 'all';
   const commitMessageRegex = new RegExp(commitMessage.replace(/{{version}}/g, `${tagPrefix}\\d+\\.\\d+\\.\\d+`), 'ig');
-  const isVersionBump = messages.find((message) => commitMessageRegex.test(message)) !== undefined;
+
+  let isVersionBump = false;
+
+  if (bumpPolicy === 'all') {
+    isVersionBump = messages.find((message) => commitMessageRegex.test(message)) !== undefined;
+  } else if (bumpPolicy === 'last-commit') {
+    isVersionBump = messages.length > 0 && commitMessageRegex.test(messages[messages.length - 1]);
+  } else if (bumpPolicy === 'ignore') {
+    console.log('Ignoring any version bumps in commits...');
+  } else {
+    console.warn(`Unknown bump policy: ${bumpPolicy}`);
+  }
 
   if (isVersionBump) {
     exitSuccess('No action necessary because we found a previous bump!');


### PR DESCRIPTION
New `bump-policy` option allows for configuring whether the version bump is skipped when a previous bump is found in the commit messages. If set to `'all'` (default/original behavior), then any commit that matches the commit message regex will trigger a bump skip. When set to `'last-commit'`, only the latest commit message will be checked for a previous bump. The last possible value, `'ignore'` will bump the version whenever the action runs, regardless of the contents of commit messages.

Addresses #82 