### PR TITLE
Add option to manually override the version type

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ Customize the messages that trigger the version bump. It must be a string, case 
                                       # defaulting to a patch bump.
     rc-wording:     'RELEASE,alpha'
 ```
+#### **version-type:** 
+Override the version type taken from the commit message. Usefull when manually running workflow via workflow_dispatch 
+```yaml
+- name:  'Automated Version Bump'
+  uses:  'phips28/gh-action-bump-version@master'
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    version-type:  'minor'
+```
 #### **default:**
 Set a default version bump to use  (optional - defaults to patch). Example:
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'Prefix that is used for the git tag'
     default: ''
     required: false
+  version-type:
+    description: 'Overrides version type from commit message'
+    default: ''
+    required: false
   minor-wording:
     description: 'Words list that trigger a minor version bump'
     default: 'feat,minor'

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Automated Version Bump
+name: Automated Version Bump with version-type
 description: Automated version bump for npm packages.
 runs:
   using: node12

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const workspace = process.env.GITHUB_WORKSPACE;
   }
 
   const allowedTypes = ['major', 'minor', 'patch', 'rc']
-  if (process.env['INPUT_VERSION-TYPE'] && allowedTypes.includes(process.env['INPUT_VERSION-TYPE'])) {
+  if (process.env['INPUT_VERSION-TYPE'] && !allowedTypes.includes(process.env['INPUT_VERSION-TYPE'])) {
     exitFailure('Invalid version type');
     return;
   }

--- a/index.js
+++ b/index.js
@@ -16,10 +16,17 @@ const workspace = process.env.GITHUB_WORKSPACE;
   const pkg = getPackageJson();
   const event = process.env.GITHUB_EVENT_PATH ? require(process.env.GITHUB_EVENT_PATH) : {};
 
-  if (!event.commits) {
+  if (!event.commits && !process.env['INPUT_VERSION-TYPE']) {
     console.log("Couldn't find any commits in this event, incrementing patch version...");
   }
 
+  const allowedTypes = ['major', 'minor', 'patch', 'rc']
+  if (process.env['INPUT_VERSION-TYPE'] && allowedTypes.includes(process.env['INPUT_VERSION-TYPE'])) {
+    exitFailure('Invalid version type');
+    return;
+  }
+
+  const versionType = process.env['INPUT_VERSION-TYPE'];
   const tagPrefix = process.env['INPUT_TAG-PREFIX'] || '';
   console.log('tagPrefix:', tagPrefix);
   const messages = event.commits ? event.commits.map((commit) => commit.message + '\n' + commit.body) : [];
@@ -62,8 +69,12 @@ const workspace = process.env.GITHUB_WORKSPACE;
   // get the pre-release prefix specified in action
   let preid = process.env.INPUT_PREID;
 
+  // case if version-type found
+  if (versionType) {
+    version = versionType;
+  }
   // case: if wording for MAJOR found
-  if (
+  else if (
     messages.some(
       (message) => /^([a-zA-Z]+)(\(.+\))?(\!)\:/.test(message) || majorWords.some((word) => message.includes(word)),
     )


### PR DESCRIPTION
Added a new option to manually override the option type if the workflow was trigerred without a commit... e.g worklofw_dispatch

issue mentioned in #140 