### PR TITLE
exit build with error if `getPackageJson` fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@ if (process.env.PACKAGEJSON_DIR) {
 }
 
 const workspace = process.env.GITHUB_WORKSPACE;
+const pkg = getPackageJson();
 
 (async () => {
-  const pkg = getPackageJson();
   const event = process.env.GITHUB_EVENT_PATH ? require(process.env.GITHUB_EVENT_PATH) : {};
 
   if (!event.commits && !process.env['INPUT_VERSION-TYPE']) {


### PR DESCRIPTION
When getPackageJson fails the build doesn't exit with error code. Seems to be because it is run within the async function (returning a promise rejection instead of an error?) 


```
(node:1496) UnhandledPromiseRejectionWarning: Error: package.json could not be found in your project's root.
    at getPackageJson (/home/runner/work/_actions/phips28/gh-action-bump-version/master/index.js:240:41)
    at /home/runner/work/_actions/phips28/gh-action-bump-version/master/index.js:[16](https://github.com/mindlercare/video-stream-2/runs/8224139485?check_suite_focus=true#step:2:17):15
    at Object.<anonymous> (/home/runner/work/_actions/phips28/gh-action-bump-version/master/index.js:236:3)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:[17](https://github.com/mindlercare/video-stream-2/runs/8224139485?check_suite_focus=true#step:2:18):47
(node:1496) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:1496) [DEP00[18](https://github.com/mindlercare/video-stream-2/runs/8224139485?check_suite_focus=true#step:2:19)] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

<hr>
<img width="972" alt="Screenshot 2022-09-07 at 11 13 24" src="https://user-images.githubusercontent.com/1652607/188840284-5c6d09a5-34cf-4c10-ac26-824ae0b440e2.png">
