### PR TITLE
change environment name to INPUT_PACKAGEJSON_DIR

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ const { EOL } = require('os');
 const path = require('path');
 
 // Change working directory if user defined PACKAGEJSON_DIR
-if (process.env.PACKAGEJSON_DIR) {
-  process.env.GITHUB_WORKSPACE = `${process.env.GITHUB_WORKSPACE}/${process.env.PACKAGEJSON_DIR}`;
+if (process.env.INPUT_PACKAGEJSON_DIR) {
+  process.env.GITHUB_WORKSPACE = `${process.env.GITHUB_WORKSPACE}/${process.env.INPUT_PACKAGEJSON_DIR}`;
   process.chdir(process.env.GITHUB_WORKSPACE);
 }
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,10 @@ const { EOL } = require('os');
 const path = require('path');
 
 // Change working directory if user defined PACKAGEJSON_DIR
-if (process.env.INPUT_PACKAGEJSON_DIR) {
+if (process.env.PACKAGEJSON_DIR) {
+  process.env.GITHUB_WORKSPACE = `${process.env.GITHUB_WORKSPACE}/${process.env.PACKAGEJSON_DIR}`;
+  process.chdir(process.env.GITHUB_WORKSPACE);
+} else if (process.env.INPUT_PACKAGEJSON_DIR) {
   process.env.GITHUB_WORKSPACE = `${process.env.GITHUB_WORKSPACE}/${process.env.INPUT_PACKAGEJSON_DIR}`;
   process.chdir(process.env.GITHUB_WORKSPACE);
 }


### PR DESCRIPTION
The action allows for an input PACKAGEJSON_DIR, but the index was just looking for the environment. Setting the environment worked, but doesn't handle for the input. Another method could be having both, but this change accounts for not changing any fields