### PR TITLE
Fix broken version-type rc

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const pkg = getPackageJson();
     console.log("Couldn't find any commits in this event, incrementing patch version...");
   }
 
-  const allowedTypes = ['major', 'minor', 'patch', 'rc']
+  const allowedTypes = ['major', 'minor', 'patch', 'prerelease']
   if (process.env['INPUT_VERSION-TYPE'] && !allowedTypes.includes(process.env['INPUT_VERSION-TYPE'])) {
     exitFailure('Invalid version type');
     return;


### PR DESCRIPTION
This was added in PR #176 but never worked for `prerelease` version type
