### PR TITLE
Feature: check-last-commit-only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,19 @@ Example:
     bump-policy: 'ignore'
 ```
 
+### **check-only-last-commit**
+
+Set check-last-commit-only to only read last commit's message (optional). Example:
+
+```yaml
+- name:  'Automated Version Bump'
+  uses:  'phips28/gh-action-bump-version@master'
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    check-last-commit-only: 'true'
+```
+
 #### [DEPRECATED] **push:**
 **DEPRECATED** Set false you want to avoid pushing the new version tag/package.json. Example:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Example:
     bump-policy: 'ignore'
 ```
 
-### **check-only-last-commit**
+#### **check-last-commit-only:**
 
 Set check-last-commit-only to only read last commit's message (optional). Example:
 

--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ inputs:
     default: 'all'
     required: false
   check-last-commit-only:
-    description: 'Check only last commit's message'
+    description: 'Check only last commit message'
     default: 'false'
     required: false
   push:

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,10 @@ inputs:
     description: 'Set version bump ignore policy'
     default: 'all'
     required: false
+  check-last-commit-only:
+    description: 'Check only last commit's message'
+    default: 'false'
+    required: false
   push:
     description: '[DEPRECATED] Set to false to skip pushing the new tag'
     default: 'true'

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ const pkg = getPackageJson();
   let messages = []
   if (checkLastCommitOnly === 'true') {
     console.log('Only checking the last commit...');
-    const commit = event.commits ? event.commits[event.commits.length - 1] : null;
+    const commit = event.commits && event.commits.lengths > 0 ? event.commits[event.commits.length - 1] : null;
     messages = commit ? [commit.message + '\n' + commit.body] : [];
   } else {
     messages = event.commits ? event.commits.map((commit) => commit.message + '\n' + commit.body) : [];

--- a/index.js
+++ b/index.js
@@ -38,17 +38,14 @@ const pkg = getPackageJson();
 
   const checkLAstCommitOnly = process.env['INPUT_CHECK-LAST-COMMIT-ONLY'] || 'false';
 
+  let messages = []
   if (checkLAstCommitOnly === 'true') {
     console.log('Only checking the last commit...');
     const commit = event.commits ? event.commits[event.commits.length - 1] : null;
-    const messages = commit ? [commit.message + '\n' + commit.body] : [];
-    await run(messages, versionType, tagPrefix, tagSuffix, pkg);
+    messages = commit ? [commit.message + '\n' + commit.body] : [];
   } else {
-    const messages = event.commits ? event.commits.map((commit) => commit.message + '\n' + commit.body) : [];
-    await run(messages, versionType, tagPrefix, tagSuffix, pkg);
+    messages = event.commits ? event.commits.map((commit) => commit.message + '\n' + commit.body) : [];
   }
-
-  const messages = event.commits ? event.commits.map((commit) => commit.message + '\n' + commit.body) : [];
 
   const commitMessage = process.env['INPUT_COMMIT-MESSAGE'] || 'ci: version bump to {{version}}';
   console.log('commit messages:', messages);

--- a/index.js
+++ b/index.js
@@ -36,10 +36,10 @@ const pkg = getPackageJson();
   console.log('tagPrefix:', tagPrefix);
   console.log('tagSuffix:', tagSuffix);
 
-  const checkLAstCommitOnly = process.env['INPUT_CHECK-LAST-COMMIT-ONLY'] || 'false';
+  const checkLastCommitOnly = process.env['INPUT_CHECK-LAST-COMMIT-ONLY'] || 'false';
 
   let messages = []
-  if (checkLAstCommitOnly === 'true') {
+  if (checkLastCommitOnly === 'true') {
     console.log('Only checking the last commit...');
     const commit = event.commits ? event.commits[event.commits.length - 1] : null;
     messages = commit ? [commit.message + '\n' + commit.body] : [];

--- a/index.js
+++ b/index.js
@@ -35,6 +35,19 @@ const pkg = getPackageJson();
   const tagSuffix = process.env['INPUT_TAG-SUFFIX'] || '';
   console.log('tagPrefix:', tagPrefix);
   console.log('tagSuffix:', tagSuffix);
+
+  const checkLAstCommitOnly = process.env['INPUT_CHECK-LAST-COMMIT-ONLY'] || 'false';
+
+  if (checkLAstCommitOnly === 'true') {
+    console.log('Only checking the last commit...');
+    const commit = event.commits ? event.commits[event.commits.length - 1] : null;
+    const messages = commit ? [commit.message + '\n' + commit.body] : [];
+    await run(messages, versionType, tagPrefix, tagSuffix, pkg);
+  } else {
+    const messages = event.commits ? event.commits.map((commit) => commit.message + '\n' + commit.body) : [];
+    await run(messages, versionType, tagPrefix, tagSuffix, pkg);
+  }
+
   const messages = event.commits ? event.commits.map((commit) => commit.message + '\n' + commit.body) : [];
 
   const commitMessage = process.env['INPUT_COMMIT-MESSAGE'] || 'ci: version bump to {{version}}';


### PR DESCRIPTION
New `check-last-commit-only` option allows for configuring whether the version bump should only check the last commit's message. If set to 'false' (default/original behaviour), then the check will be made on all commit messages as usual. When set to 'true', only the latest commit message will be checked for a possible bump.

Addresses https://github.com/phips28/gh-action-bump-version/issues/82 when there are no active bumpers in other branches, but one would still want to check only the last commit message. This is particularly useful when we want to check only for a merged PR title for the bumping.