### PR TITLE
Filter out empty strings for major/minor bump checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,8 +71,8 @@ const pkg = getPackageJson();
   }
 
   // input wordings for MAJOR, MINOR, PATCH, PRE-RELEASE
-  const majorWords = process.env['INPUT_MAJOR-WORDING'].split(',');
-  const minorWords = process.env['INPUT_MINOR-WORDING'].split(',');
+  const majorWords = process.env['INPUT_MAJOR-WORDING'].split(',').filter((word) => word != '');
+  const minorWords = process.env['INPUT_MINOR-WORDING'].split(',').filter((word) => word != '');
   // patch is by default empty, and '' would always be true in the includes(''), thats why we handle it separately
   const patchWords = process.env['INPUT_PATCH-WORDING'] ? process.env['INPUT_PATCH-WORDING'].split(',') : null;
   const preReleaseWords = process.env['INPUT_RC-WORDING'] ? process.env['INPUT_RC-WORDING'].split(',') : null;


### PR DESCRIPTION
When setting `major-wording` or `minor-wording` to `''` (which I assumed would disable all word search checks) it actually makes every commit a major bump, becuase it searches for that empty string in the commit message. 

This PR filters out empty strings so that the major/minor words array is empty instead, as a user would expect. 