### PR TITLE
feat: add support for regular expressions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,10 @@ inputs:
     description: 'Check only last commit message'
     default: 'false'
     required: false
+  use-regular-expression:
+    description: 'Use regular expression for version wording instead of comma separated string'
+    default: false
+    required: false
   push:
     description: '[DEPRECATED] Set to false to skip pushing the new tag'
     default: 'true'


### PR DESCRIPTION
Added support for regular expressions to be used instead of comma separated string list. This solves the case where for instance a commit message contains any of the keywords in the middle and gives better control to the developer on what commit messages to trigger on.

Adds `use-regular-expression` flag in order to not break existing implementation. Example: 
```
with:
  use-regular-expression: true
  minor-wording: "^feat\\:"
  major-wording: "^(feat|fix)\\!\\:"
  patch-wording: "^(refactor|fix)\\:"
  pre-release:   "^pre-(alpha|beta|rc)\\:"
```

The above example matches only if message starts with the wording. In the case of pre-release it matches the first group and uses that word for the release. For instance `pre-rc: foobar` gives version `x.y.z-rc.0`

Unfortunately it got a bit messy in order to not breaking existing functionality.