### PR TITLE
Tag events: Always fetch branches

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,11 +205,8 @@ const pkg = getPackageJson();
       await runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);
     }
 
-    // now go to the actual branch to perform the same versioning
-    if (isPullRequest) {
-      // First fetch to get updated local version of branch
-      await runInWorkspace('git', ['fetch']);
-    }
+    // First fetch to get updated local version of branch
+    await runInWorkspace('git', ['fetch']);
     await runInWorkspace('git', ['checkout', currentBranch]);
     await runInWorkspace('npm', ['version', '--allow-same-version=true', '--git-tag-version=false', current]);
     console.log('current 2:', current, '/', 'version:', version);


### PR DESCRIPTION
GHA fails with:

```
✖  fatal     error: pathspec 'main' did not match any file(s) known to git

git exited with code 1
✖  fatal     Failed to bump version
```
if we don't fetch the branches. 