### PR TITLE
Revert "Tag events: Always fetch branches"

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,8 +205,11 @@ const pkg = getPackageJson();
       await runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);
     }
 
-    // First fetch to get updated local version of branch
-    await runInWorkspace('git', ['fetch']);
+    // now go to the actual branch to perform the same versioning
+    if (isPullRequest) {
+      // First fetch to get updated local version of branch
+      await runInWorkspace('git', ['fetch']);
+    }
     await runInWorkspace('git', ['checkout', currentBranch]);
     await runInWorkspace('npm', ['version', '--allow-same-version=true', '--git-tag-version=false', current]);
     console.log('current 2:', current, '/', 'version:', version);


### PR DESCRIPTION
Reverts phips28/gh-action-bump-version#224

fails for some users: https://github.com/phips28/gh-action-bump-version/commit/dfc3f132b5ff746744717b731acf6a1c77229a54#commitcomment-128999422