### PR TITLE
feat: add support for alternative git provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,20 @@ Set check-last-commit-only to only read last commit's message (optional). Exampl
     check-last-commit-only: 'true'
 ```
 
+#### **custom-git-domain:**
+
+Set a custom domain of the git instance (optional). This is only needed, when using self-hosted instances of GitHub or alternative git provider (e.g. Gitea).
+Example:
+
+```yaml
+- name:  'Automated Version Bump'
+  uses:  'phips28/gh-action-bump-version@master'
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    custom-git-domain: 'github.com'
+```
+
 #### [DEPRECATED] **push:**
 **DEPRECATED** Set false you want to avoid pushing the new version tag/package.json. Example:
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
     required: false
   skip-push:
     description: 'If true, skip pushing any commits or tags created after the version bump'
-    default: false
+    default: 'false'
     required: false
   PACKAGEJSON_DIR:
     description: 'Custom dir to the package'

--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,10 @@ inputs:
     description: 'Check only last commit message'
     default: 'false'
     required: false
+  custom-git-domain:
+    description: 'Set a custom domain of the git instance'
+    default: 'github.com'
+    required: false
   push:
     description: '[DEPRECATED] Set to false to skip pushing the new tag'
     default: 'true'

--- a/index.js
+++ b/index.js
@@ -240,7 +240,7 @@ const pkg = getPackageJson();
       );
     }
 
-    const remoteRepo = `https://${process.env.GITHUB_ACTOR}:${process.env.GITHUB_TOKEN}@github.com/${process.env.GITHUB_REPOSITORY}.git`;
+    const remoteRepo = `https://${process.env.GITHUB_ACTOR}:${process.env.GITHUB_TOKEN}@${process.env.CUSTOM_GIT_URL || "github.com"}/${process.env.GITHUB_REPOSITORY}.git`;
     if (process.env['INPUT_SKIP-TAG'] !== 'true') {
       await runInWorkspace('git', ['tag', newVersion]);
       if (process.env['INPUT_SKIP-PUSH'] !== 'true') {

--- a/index.js
+++ b/index.js
@@ -240,7 +240,7 @@ const pkg = getPackageJson();
       );
     }
 
-    const remoteRepo = `https://${process.env.GITHUB_ACTOR}:${process.env.GITHUB_TOKEN}@${process.env.CUSTOM_GIT_URL || "github.com"}/${process.env.GITHUB_REPOSITORY}.git`;
+    const remoteRepo = `https://${process.env.GITHUB_ACTOR}:${process.env.GITHUB_TOKEN}@${process.env['INPUT_CUSTOM-GIT-DOMAIN'] || "github.com"}/${process.env.GITHUB_REPOSITORY}.git`;
     if (process.env['INPUT_SKIP-TAG'] !== 'true') {
       await runInWorkspace('git', ['tag', newVersion]);
       if (process.env['INPUT_SKIP-PUSH'] !== 'true') {


### PR DESCRIPTION
Hello there!
Unfortunately, the provider "github.com" has been hardcoded, which makes it impossible to use this action on self-hosted instances. My PR offers the possibility to define own Git instances via an environment variable with the default fallback "github.com", which was already defined before.