### PR TITLE
Upgrade to node20 + Support for choosing prepatch, preminor and premajor version types 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .nyc_output
 /test-repo
 /.env
+.idea

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: Automated Version Bump
-description: Automated version bump for npm packages.
+name: Version Bump by nahuelhds
+description: Fork from Automated version bump.
 runs:
   using: node16
   main: index.js

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: Version Bump by nahuelhds
 description: Fork from Automated version bump.
 runs:
-  using: node16
+  using: node20
   main: index.js
 branding:
   icon: chevron-up

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: Version Bump by nahuelhds
-description: Fork from Automated version bump.
+name: Automated Version Bump
+description: Automated version bump for npm packages.
 runs:
   using: node20
   main: index.js

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const pkg = getPackageJson();
     console.log("Couldn't find any commits in this event, incrementing patch version...");
   }
 
-  const allowedTypes = ['major', 'minor', 'patch', 'prerelease'];
+  const allowedTypes = ['major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', 'prerelease'];
   if (process.env['INPUT_VERSION-TYPE'] && !allowedTypes.includes(process.env['INPUT_VERSION-TYPE'])) {
     exitFailure('Invalid version type');
     return;
@@ -38,7 +38,7 @@ const pkg = getPackageJson();
 
   const checkLastCommitOnly = process.env['INPUT_CHECK-LAST-COMMIT-ONLY'] || 'false';
 
-  let messages = []
+  let messages = [];
   if (checkLastCommitOnly === 'true') {
     console.log('Only checking the last commit...');
     const commit = event.commits && event.commits.lengths > 0 ? event.commits[event.commits.length - 1] : null;
@@ -51,7 +51,10 @@ const pkg = getPackageJson();
   console.log('commit messages:', messages);
 
   const bumpPolicy = process.env['INPUT_BUMP-POLICY'] || 'all';
-  const commitMessageRegex = new RegExp(commitMessage.replace(/{{version}}/g, `${tagPrefix}\\d+\\.\\d+\\.\\d+${tagSuffix}`), 'ig');
+  const commitMessageRegex = new RegExp(
+    commitMessage.replace(/{{version}}/g, `${tagPrefix}\\d+\\.\\d+\\.\\d+${tagSuffix}`),
+    'ig',
+  );
 
   let isVersionBump = false;
 
@@ -236,11 +239,13 @@ const pkg = getPackageJson();
     } catch (e) {
       console.warn(
         'git commit failed because you are using "actions/checkout@v2" or later; ' +
-        'but that doesnt matter because you dont need that git commit, thats only for "actions/checkout@v1"',
+          'but that doesnt matter because you dont need that git commit, thats only for "actions/checkout@v1"',
       );
     }
 
-    const remoteRepo = `https://${process.env.GITHUB_ACTOR}:${process.env.GITHUB_TOKEN}@${process.env['INPUT_CUSTOM-GIT-DOMAIN'] || "github.com"}/${process.env.GITHUB_REPOSITORY}.git`;
+    const remoteRepo = `https://${process.env.GITHUB_ACTOR}:${process.env.GITHUB_TOKEN}@${
+      process.env['INPUT_CUSTOM-GIT-DOMAIN'] || 'github.com'
+    }/${process.env.GITHUB_REPOSITORY}.git`;
     if (process.env['INPUT_SKIP-TAG'] !== 'true') {
       await runInWorkspace('git', ['tag', newVersion]);
       if (process.env['INPUT_SKIP-PUSH'] !== 'true') {

--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ const pkg = getPackageJson();
   }
 
   // case: if default=prerelease, but rc-wording is NOT set
-  if (version === 'prerelease' && preid) {
+  if (['prerelease', 'prepatch', 'preminor', 'premajor'].contains(version) && preid) {
     version = `${version} --preid=${preid}`;
   }
 

--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ const pkg = getPackageJson();
   }
 
   // case: if default=prerelease, but rc-wording is NOT set
-  if (['prerelease', 'prepatch', 'preminor', 'premajor'].contains(version) && preid) {
+  if (['prerelease', 'prepatch', 'preminor', 'premajor'].includes(version) && preid) {
     version = `${version} --preid=${preid}`;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gh-action-bump-version",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gh-action-bump-version",
-      "version": "10.1.1",
+      "version": "10.1.2",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^27.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gh-action-bump-version",
-  "version": "10.1.3",
+  "version": "10.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gh-action-bump-version",
-      "version": "10.1.3",
+      "version": "10.1.4",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^27.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gh-action-bump-version",
-  "version": "10.1.2",
+  "version": "10.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gh-action-bump-version",
-      "version": "10.1.2",
+      "version": "10.1.3",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^27.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gh-action-bump-version",
-  "version": "10.1.4",
+  "version": "10.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gh-action-bump-version",
-      "version": "10.1.4",
+      "version": "10.2.0",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^27.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-action-bump-version",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/phips28/gh-action-bump-version.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-action-bump-version",
-  "version": "10.1.2",
+  "version": "10.1.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/phips28/gh-action-bump-version.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-action-bump-version",
-  "version": "10.1.4",
+  "version": "10.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/phips28/gh-action-bump-version.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-action-bump-version",
-  "version": "10.1.3",
+  "version": "10.1.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/phips28/gh-action-bump-version.git"


### PR DESCRIPTION
I wanted to possibility to bump preminor and premajor versions on my CI based on gitflow and semver.

So I've done this little change to make that possible.

A full working example of this change can be seen on [this example repo](https://github.com/nahuelhds/ci-semver-gitflow-actions) which is using my fork.

If anything else is required for make this PR to be merged, just let me know.