### PR TITLE
Add no-verify option for git commits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,10 @@ inputs:
     description: 'Set a custom domain of the git instance'
     default: 'github.com'
     required: false
+  git-no-verify:
+    description: 'Skip precommit hooks'
+    default: 'false'
+    required: false
   push:
     description: '[DEPRECATED] Set to false to skip pushing the new tag'
     default: 'true'

--- a/action.yml
+++ b/action.yml
@@ -78,8 +78,8 @@ inputs:
     description: 'Set a custom domain of the git instance'
     default: 'github.com'
     required: false
-  git-no-verify:
-    description: 'Skip precommit hooks'
+  commit-no-verify:
+    description: 'Skip commit hooks'
     default: 'false'
     required: false
   push:

--- a/index.js
+++ b/index.js
@@ -238,7 +238,7 @@ const pkg = getPackageJson();
     try {
       // to support "actions/checkout@v1"
       if (process.env['INPUT_SKIP-COMMIT'] !== 'true') {
-        if (process.env['INPUT_GIT-NO-VERIFY'] === 'true') {
+        if (process.env['INPUT_COMMIT-NO-VERIFY'] === 'true') {
           await runInWorkspace('git', ['commit', '-a', '--no-verify', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);
         } else {
           await runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);

--- a/index.js
+++ b/index.js
@@ -238,7 +238,11 @@ const pkg = getPackageJson();
     try {
       // to support "actions/checkout@v1"
       if (process.env['INPUT_SKIP-COMMIT'] !== 'true') {
-        await runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);
+        if (process.env['INPUT_GIT-NO-VERIFY'] === 'true') {
+          await runInWorkspace('git', ['commit', '-a', '--no-verify', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);
+        } else {
+          await runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);
+        }
       }
     } catch (e) {
       // console.warn(


### PR DESCRIPTION
In response to https://github.com/phips28/gh-action-bump-version/issues/243, I've added an option of: `git-no-verify` that will run the git commit command with the `--no-verify` option enabled.

fix #243